### PR TITLE
Fix gam7 formula URL selection

### DIFF
--- a/Formula/gam7.rb
+++ b/Formula/gam7.rb
@@ -3,32 +3,25 @@ class Gam7 < Formula
   homepage "https://github.com/GAM-team/GAM"
   version "7.34.11"
 
-  on_macos do
-    on_arm do
+  if OS.mac?
+    if Hardware::CPU.arm?
       url "https://github.com/GAM-team/GAM/releases/download/v7.34.11/gam-7.34.11-macos26.3-arm64.tar.xz"
       sha256 "3d18e3f3604113ebaeca98fe2871c345ca60e477e615e6ed3b903e59cfdc91d1"
-    end
-    on_intel do
+    else
       url "https://github.com/GAM-team/GAM/releases/download/v7.34.11/gam-7.34.11-macos26.3-x86_64.tar.xz"
       sha256 "794989ad47bb4509e0b62df6e310edb02562a5f1b0bf090594e75e725d6cfc65"
     end
-  end
-
-  on_linux do
-    on_arm do
+  elsif OS.linux?
+    if Hardware::CPU.arm?
       url "https://github.com/GAM-team/GAM/releases/download/v7.34.11/gam-7.34.11-linux-arm64-legacy.tar.xz"
       sha256 "7c3c56c8005bf392ce1dd6d64d61887074e7d1b458b99b6528a918047ea8b06f"
-    end
-    on_intel do
+    else
       url "https://github.com/GAM-team/GAM/releases/download/v7.34.11/gam-7.34.11-linux-x86_64-legacy.tar.xz"
       sha256 "753f7db6b54c03d0f9bfd38afb6fe652f36a058c3c65a4e919b37eafce95d9d3"
     end
   end
 
   def install
-    # The tarball extracts to a directory named 'gam7'.
-    # Homebrew automatically cd's into that directory if it's the only one.
-    # We install all files to libexec and link the binary.
     libexec.install Dir["*"]
     bin.install_symlink libexec/"gam"
   end

--- a/scripts/update_gam.py
+++ b/scripts/update_gam.py
@@ -105,6 +105,8 @@ def update_formula():
 
     current_os = None
     current_arch = None
+    in_os_block = False
+    in_arch_block = False
 
     updated_keys = set()
 
@@ -115,19 +117,25 @@ def update_formula():
         if stripped.startswith('version "'):
             line = re.sub(r'version ".*?"', f'version "{version}"', line)
 
-        if stripped == 'on_macos do':
+        # OS-level state transitions (if OS.mac? / elsif OS.linux? syntax)
+        if stripped == 'if OS.mac?':
             current_os = 'macos'
-        elif stripped == 'on_linux do':
+            in_os_block = True
+        elif stripped == 'elsif OS.linux?':
             current_os = 'linux'
-        elif stripped == 'on_arm do':
+            # in_os_block stays True; inner arch block already closed by its own end
+        # Arch-level state transitions (only inside an OS block)
+        elif in_os_block and not in_arch_block and stripped == 'if Hardware::CPU.arm?':
             current_arch = 'arm'
-        elif stripped == 'on_intel do':
+            in_arch_block = True
+        elif in_arch_block and stripped == 'else':
             current_arch = 'intel'
-
-        if stripped == 'end':
-            if current_arch:
+        elif stripped == 'end':
+            if in_arch_block:
+                in_arch_block = False
                 current_arch = None
-            elif current_os:
+            elif in_os_block:
+                in_os_block = False
                 current_os = None
 
         if current_os and current_arch:


### PR DESCRIPTION
Thanks for starting a GAM homebrew tap! I was successfully getting it to run when invoked directly, but was failing in my Brewfile. On my Homebrew 5 / macOS arm64 setup, the existing formula fails metadata evaluation with:

`formula requires at least a URL`

I've updated `gam7.rb` to select a concrete `url`/`sha256` at formula load time using the new `if OS.mac?` / `Hardware::CPU.arm?` syntax rather than the current nested `on_macos` / `on_arm` blocks.

